### PR TITLE
Update README with Docker usage notes for terminals/增加 PowerShell 运行命令的兼容性说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ MI_COOKIE='xxxxxx'
 ```bash
 docker run -it --rm --env-file $(pwd)/env -v $(pwd)/public/data:/app/public/data idootop/mi-note-sync:latest
 ```
+ **注意**：
+ - 如果您在 **Linux / macOS / WSL (Bash)** 终端运行，请使用 `$(pwd)`：
+  ```bash
+  docker run ... -v $(pwd)/public/data:/app/public/data ...
+  ```
+  - 如果您在 **Windows PowerShell** 终端运行，请将 `$(pwd)` 替换为 `${PWD}`：
+  ```powershell
+  docker run ... -v ${PWD}/public/data:/app/public/data ...
+  ```
 
 > [!NOTE]
 > 暂不支持备份私密笔记、待办和思维导图

--- a/README.md
+++ b/README.md
@@ -38,13 +38,9 @@ MI_COOKIE='xxxxxx'
 docker run -it --rm --env-file $(pwd)/env -v $(pwd)/public/data:/app/public/data idootop/mi-note-sync:latest
 ```
  **注意**：
- - 如果您在 **Linux / macOS / WSL (Bash)** 终端运行，请使用 `$(pwd)`：
-  ```bash
-  docker run ... -v $(pwd)/public/data:/app/public/data ...
-  ```
-  - 如果您在 **Windows PowerShell** 终端运行，请将 `$(pwd)` 替换为 `${PWD}`：
+  - 如果你在 **Windows** 上使用 **PowerShell** 运行，请将 `$(pwd)` 替换为 `${pwd}`：
   ```powershell
-  docker run ... -v ${PWD}/public/data:/app/public/data ...
+  docker run -it --rm --env-file ${pwd}/env -v ${pwd}/public/data:/app/public/data idootop/mi-note-sync:latest
   ```
 
 > [!NOTE]


### PR DESCRIPTION
你好！我在使用该项目时发现，Windows PowerShell 用户直接复制 README 中的命令会报错，因为 PowerShell 不支持 $(pwd) 语法，需要改为 ${PWD}。
我在 README 中补充了针对 PowerShell 用户的说明，希望能帮助更多 Windows 用户顺利上手。